### PR TITLE
melete: 0.2.0, sakaki-only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,7 @@
 # CLAUDE.md — dxflake
 
 A multi-host NixOS flake (`chiyo` laptop · `osaka` workstation · `sakaki` server).
+Melete (the AI agent harness, `dx.melete.enable`) runs sakaki-only — pinned client v0.2.0 in `pkgs/melete/default.nix`.
 This file is a **registry**: where things live and how to add them. For the *why*,
 read `README.md` (*Architecture overview*, *Adding a module*) and the Magi wiki (below).
 

--- a/hosts/chiyo/default.nix
+++ b/hosts/chiyo/default.nix
@@ -7,7 +7,8 @@
   dx.bluetooth.enable = true;
   dx.syncthing.enable = true;
   dx.laptop.enable = true;
-  dx.melete.enable = true;
+  # consolidated to sakaki-only, 2026-07-31
+  dx.melete.enable = false;
   dx.gpu-intel.enable = true;
   boot = {
     initrd.kernelModules = [ "nvme" ];

--- a/hosts/osaka/default.nix
+++ b/hosts/osaka/default.nix
@@ -11,7 +11,8 @@
   dx.gpu-amd.enable = true;
   dx.gpu-screen-recorder.enable = true;
   dx.k3b.enable = true;
-  dx.melete.enable = true;
+  # consolidated to sakaki-only, 2026-07-31
+  dx.melete.enable = false;
   dx.nas-mounts = {
     enable = true;
     mounts."/mnt/kaori-media".export = "/volume1/media";

--- a/pkgs/melete/default.nix
+++ b/pkgs/melete/default.nix
@@ -5,8 +5,8 @@
 }:
 
 # Pinned to this release's SHA256SUMS
-# (github.com/noah427/melete releases/tag/canary-efc05e7):
-#   08dbed6f32a1e28ab8dba2c0d7120ae4f76148bb548f913d4a1031e3e8df8183  melete-x86_64-unknown-linux-musl
+# (github.com/noah427/melete releases/tag/0.2.0):
+#   dfee72235c50b5ae5defe880e666c3ad5fd6835e15413db51a1daa03ded4ca25  melete-x86_64-unknown-linux-musl
 # BUMPING THIS: if the rebuild fails with `curl: (22) ... error: 401`, do NOT
 # assume the token is dead or the release is unpublished. The likely cause is
 # that this host's RUNNING generation predates the impure-env wiring in
@@ -21,7 +21,7 @@
 # names the store path after the FILE, so the temp file must be named exactly
 # melete-bin-<version> or the FOD will not match it and the fetch runs anyway.
 let
-  version = "canary-efc05e7";
+  version = "0.2.0";
 
   # Fixed-output fetch via our OWN curl call, not fetchurl. fetchurl passes
   # curlOptsList as a quoted bash array ("${curlOptsList[@]}"), so a literal
@@ -37,7 +37,7 @@ let
 
     outputHashMode = "flat";
     outputHashAlgo = "sha256";
-    outputHash = "sha256-CNvtbzKh4oq426LA1xIK5PdhSLtUj5E9ShAx4+jfgYM=";
+    outputHash = "sha256-3+5yI1xQta5d7+iA5mbDrV/Wg14VQT21Gh2qA97UyiU=";
 
     __impureEnvVars = [ "NIX_MELETE_READ_TOKEN" ];
     SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";


### PR DESCRIPTION
Three commits, each a separate concern:
- bump pinned client canary-efc05e7 -> 0.2.0 (pkgs/melete/default.nix)
- disable dx.melete.enable on osaka + chiyo, sakaki stays the only instance
- CLAUDE.md note reflecting the above

Eval-checked clean (nix flake check --no-build, all 4 hosts). Not deployed — needs nixos-rebuild switch on sakaki after merge (and current generation must already have the impure-env token wiring, see the COLD-HOST CATCH-22 comment in modules/dendrites/melete.nix, or the 0.2.0 fetch will 401).