### PR TITLE
sakaki: rename dispo.necoconeco.net -> weedaq.necoconeco.net

### DIFF
--- a/hosts/sakaki/default.nix
+++ b/hosts/sakaki/default.nix
@@ -49,7 +49,7 @@
       # (one apps/gate_token for every app it fronts; app.toml has no per-app
       # auth field), and this is the one app meant to be readable without a
       # login.
-      "dispo.necoconeco.net"
+      "weedaq.necoconeco.net"
     ];
   };
   dx.caddy = {
@@ -103,7 +103,7 @@
       # is not GET/HEAD is refused at the edge before it reaches Rune. The
       # scraper is unaffected -- it POSTs to 127.0.0.1:8110 on the box, where
       # Caddy never sees the request.
-      "dispo.necoconeco.net".extraConfig = ''
+      "weedaq.necoconeco.net".extraConfig = ''
         @writes not method GET HEAD
         respond @writes "dispo-index is read-only over the public hostname" 405
 


### PR DESCRIPTION
The app's own display name is Weedaq (app.toml title, page h1/title). This brings the public hostname in line -- same tunnel hostnames entry, same Caddy site block (port 8110, write-guard unchanged), key renamed.

App slug stays dispo-index (directory, deployed.json, dispo-public.service's ExecStart, GitHub repo) -- domain and app slug are decoupled here, so this is a hostname-only change. Needs:
- Cloudflare DNS: dispo.necoconeco.net currently resolves (per-hostname A/AAAA via the tunnel), weedaq.necoconeco.net is NXDOMAIN -- no wildcard, so a new DNS record is required alongside this before the hostname works.
- nixos-rebuild switch on sakaki to apply.
- Old dispo.necoconeco.net stops resolving once removed here -- drop the old DNS record too, or leave both live during a transition.