### PR TITLE
pi: register npm:pi-cache-optimizer extension

### DIFF
--- a/modules/dendrites/pi-coding-agent.nix
+++ b/modules/dendrites/pi-coding-agent.nix
@@ -110,6 +110,7 @@ in
             "npm:pi-mcp-adapter"
             "npm:pi-web-access"
             "npm:context-mode"
+            "npm:pi-cache-optimizer"
           ];
         };
       };


### PR DESCRIPTION
Adds the pi-cache-optimizer pi package (v2.8.3) to the declarative pi install in `modules/dendrites/pi-coding-agent.nix`.

The npm dependency was already fetched into `~/.pi/agent/npm/`; this registers it in settings so pi loads it on startup.