### PR TITLE
sakaki: mount /volume1/dong at /mnt/dong (Đồng photo uploads)

### DIFF
--- a/hosts/sakaki/default.nix
+++ b/hosts/sakaki/default.nix
@@ -20,6 +20,11 @@
         "transmission"
       ];
     };
+    # Đồng (dxcently/dong): direct photo uploads only. Photos already in
+    # Immich are referenced in place on /mnt/immich and never copied here.
+    # No requiredBy: the app starts without it and autofs mounts on first
+    # write, so a missing export cannot take melete down with it.
+    mounts."/mnt/dong".export = "/volume1/dong";
   };
   dx.mneme.enable = true;
   dx.immich.enable = true;


### PR DESCRIPTION
Adds the kaori export `volume1/dong` to sakaki's `dx.nas-mounts`, mounted at `/mnt/dong`, for direct photo uploads into Đồng (dxcently/dong). Photos already in Immich are referenced in place on `/mnt/immich`, never copied, so this share only ever holds uploads.

No `requiredBy`: Đồng starts fine without the share and autofs mounts it on first write, so a missing export cannot take `melete.service` down.

**Merge after** the share exists on kaori (DSM: Shared Folder `dong` on volume1, NFS permission for 192.168.1.202, read/write, same squash setting as the immich share), then `dxrebuild` on sakaki and confirm with `ls /mnt/dong`.