### PR TITLE
sakaki: dong.necoconeco.net -> ungated loopback :8111, app-side login

### DIFF
--- a/hosts/sakaki/default.nix
+++ b/hosts/sakaki/default.nix
@@ -59,6 +59,13 @@
       # melete.necoconeco.net/weedaq/ via apps.gateway_apps.
       "weedaq.com"
       "www.weedaq.com"
+      # Đồng (dxcently/dong), shared with a few people under ONE shared
+      # password of its own, so it cannot sit behind the gateway's single
+      # login. Same shape as weedaq: an ungated loopback bind (:8111, the
+      # dong-public user unit) fronted by Caddy; the app's own /login is the
+      # door. The daemon-hosted copy on :8107 stays token-gated as the agent
+      # door (run_app_tool) and is also folded at melete.necoconeco.net/dong/.
+      "dong.necoconeco.net"
 
       # FAU Cyber Security Club wiki (Hugo + relearn), test hostname. Static
       # build output only: `hugo server` is a development server -- livereload
@@ -129,6 +136,14 @@
       "www.weedaq.com".extraConfig = ''
         redir https://weedaq.com{uri} 301
       '';
+
+      # Đồng, public with its own login. Port 8111 is the ungated loopback
+      # bind (dong-public user unit, ~/.config/systemd/user), the same trick
+      # as weedaq's 8110. Unlike weedaq there is no method guard: writes are
+      # the point, and the app refuses every page and every /api/* route
+      # without its session cookie. Bare proxy; Caddy forwards
+      # X-Forwarded-Proto so the app marks its cookie Secure.
+      "dong.necoconeco.net".proxy = "http://127.0.0.1:8111";
 
       # file_server, not a proxy: 90 prerendered pages, no runtime behind
       # them. webRoot is a quoted STRING rather than a path literal -- a


### PR DESCRIPTION
Adds `dong.necoconeco.net` to sakaki's tunnel hostnames and a bare Caddy proxy to `127.0.0.1:8111`, the ungated loopback bind served by the `dong-public` user unit (`~/.config/systemd/user/dong-public.service`, written, not yet enabled). Same shape as weedaq's :8110, without the method guard: Đồng does its own session login on every page and every `/api/*` route, and writes are the point.

**Do not merge until** the login PR on dxcently/dong (code-00189 + its Opus review) is merged and deployed and the shared password is set; until then :8111 would serve the app unauthenticated to anyone who reaches the hostname. Order: merge dong login → `melete apps install ~/dong/apps/dong --upgrade --deploy` → set password → `systemctl --user enable --now dong-public` → merge this → `dxrebuild` → `cloudflared tunnel route dns 304afa6f-0ac6-4d0e-abf1-206cde260bd3 dong.necoconeco.net`.