### PR TITLE
sakaki/caddy: route Đồng's photos and share uploads to the photo server

### DIFF
--- a/hosts/sakaki/default.nix
+++ b/hosts/sakaki/default.nix
@@ -141,9 +141,42 @@
       # bind (dong-public user unit, ~/.config/systemd/user), the same trick
       # as weedaq's 8110. Unlike weedaq there is no method guard: writes are
       # the point, and the app refuses every page and every /api/* route
-      # without its session cookie. Bare proxy; Caddy forwards
-      # X-Forwarded-Proto so the app marks its cookie Secure.
-      "dong.necoconeco.net".proxy = "http://127.0.0.1:8111";
+      # without its session cookie. Caddy forwards X-Forwarded-Proto so the
+      # app marks its cookie Secure.
+      #
+      # Three paths go to the photo server (dong-photos user unit, 8203)
+      # instead of the app, because Melete's app host cannot serve image
+      # bytes: it has no filesystem capability and every reply is one 200
+      # text/html body. Every photograph now lives in Immich (the worker
+      # moves uploads there and drops the SQLite copy), so without this
+      # block every card is a grey box -- the app answers those paths with an
+      # HTML session shim that an <img> cannot render. The share paths are
+      # the worker's for a different reason: the host hands an app its body
+      # as from_utf8_lossy, which destroys a multipart JPEG before the app
+      # sees it. `handle` (not handle_path) for those: the worker matches the
+      # full path. NOT /api/share/* -- /api/share/token is the app's own.
+      #
+      # sw.js: a service worker may only claim a scope at or below its own
+      # directory, and this one lives under /static/ but needs the app root;
+      # the host cannot send the header that allows it, so Caddy does.
+      #
+      # Caddy evaluates handle/handle_path before a bare reverse_proxy
+      # regardless of textual order, so `proxy` stays the catch-all.
+      # See deploy/dong-workers.md §5 in dxcently/dong.
+      "dong.necoconeco.net" = {
+        proxy = "http://127.0.0.1:8111";
+        extraConfig = ''
+          handle_path /immich-photos/* {
+            reverse_proxy 127.0.0.1:8203
+          }
+          handle /api/share/upload    { reverse_proxy 127.0.0.1:8203 }
+          handle /api/share/parked/*  { reverse_proxy 127.0.0.1:8203 }
+          handle /static/sw.js {
+            header Service-Worker-Allowed "/"
+            reverse_proxy 127.0.0.1:8111
+          }
+        '';
+      };
 
       # file_server, not a proxy: 90 prerendered pages, no runtime behind
       # them. webRoot is a quoted STRING rather than a path literal -- a


### PR DESCRIPTION
Every photograph in Đồng now lives in Immich (the worker moves uploads there and drops the SQLite copy), and the app cannot serve a file — Melete's host has no filesystem capability and every reply is one `200 text/html` body. `GET /api/photos/{id}` therefore answers with a URL under `/immich-photos/`, and the browser fetches the bytes from `dong-worker serve-photos` (the `dong-photos` user unit on `127.0.0.1:8203`).

Without a proxy rule those requests fall through to the app, which answers with an HTML session-retry shim an `<img>` cannot render: **every card is a grey box on the public hostname right now.** That is the live state as of this PR.

Three handle blocks, per `deploy/dong-workers.md` §5 in dxcently/dong:

| path | upstream | why |
|---|---|---|
| `/immich-photos/*` | 8203 | `handle_path`: the server takes the rest |
| `/api/share/upload`, `/api/share/parked/*` | 8203 | `handle`: the worker matches the full path. **Not** `/api/share/*` — `/api/share/token` is the app's own |
| `/static/sw.js` | 8111 + `Service-Worker-Allowed: /` | a service worker may only claim its own directory's scope; the host cannot send that header itself |

Caddy evaluates `handle`/`handle_path` before a bare `reverse_proxy` regardless of textual order, so the existing `proxy` setting stays the catch-all.

**Verified:** `nix eval` of the rendered virtualHost `extraConfig` produces exactly the documented Caddyfile. `serve-photos` is already running on sakaki as `dong-photos.service` and returns real image bytes on 8203 (tested: `image/webp`, 19.6 KB, 250×333). Only this rule is missing.

**After merge:** `dxrebuild` on sakaki, then photos return on the public hostname. No app deploy needed.
